### PR TITLE
Setup Auto Fix Option for Rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-logical-css",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Stylelint plugin to enforce the use of logical CSS properties, values and units.",
   "main": "src/index.js",
   "files": [

--- a/src/rules/use-logical-properties-and-values/index.js
+++ b/src/rules/use-logical-properties-and-values/index.js
@@ -8,9 +8,15 @@ const { isPhysicalValue } = require('../../utils/isPhysicalValue');
 const { physicalPropertiesMap } = require('../../utils/physicalPropertiesMap');
 const { physicalValuesMap } = require('../../utils/physicalValuesMap');
 
-const ruleFunction = () => {
+const ruleFunction = (_, options, context) => {
   return (root, result) => {
-    const validOptions = stylelint.utils.validateOptions(result, ruleName);
+    const validOptions = stylelint.utils.validateOptions(result, ruleName, [
+      {
+        action: 'enableAutoFix',
+        possible: [true, false],
+        optional: true,
+      },
+    ]);
 
     if (!validOptions) {
       return;
@@ -32,6 +38,18 @@ const ruleFunction = () => {
             decl.value,
             physicalValuesMap[decl.prop][decl.value],
           );
+
+      if (context.fix && options.enableAutoFix) {
+        if (propIsPhysical) {
+          decl.prop = physicalPropertiesMap[decl.prop];
+        }
+
+        if (valueIsPhysical) {
+          decl.value = physicalValuesMap[decl.value];
+        }
+
+        return;
+      }
 
       stylelint.utils.report({
         message,


### PR DESCRIPTION
## 📒 Description

Adds an `enabledAutoFix` option, to optionally opt into the `--fix` option in Stylelint.

## 🚀 Changes

Sets up the `context` and `options` for auto fixing into `use-logical-propertie4s-and-values` rule.

## 🔐 Closes

N/A

## ⛳️ Testing

 N/A