### PR TITLE
Support Individual Property Options

### DIFF
--- a/src/rules/use-logical-properties-and-values/index.js
+++ b/src/rules/use-logical-properties-and-values/index.js
@@ -20,6 +20,16 @@ const ruleFunction = (_, options, context) => {
 
     root.walkDecls((decl) => {
       let rootProp = decl.prop;
+      if (options?.[rootProp] === false || options?.[rootProp] === 'off') {
+        console.log({
+          decl,
+          parent: decl.parent,
+          source: decl.source,
+          parentSource: decl.parent.source,
+        });
+        return;
+      }
+
       vendorPrefixes.forEach(
         (prefix) => (rootProp = rootProp.replace(prefix, '')),
       );
@@ -56,6 +66,9 @@ const ruleFunction = (_, options, context) => {
       }
 
       stylelint.utils.report({
+        column: decl.source.start.column,
+        endColumn: rootProp.length,
+        line: decl.source.start.line,
         message,
         node: decl,
         result,

--- a/src/rules/use-logical-properties-and-values/index.test.js
+++ b/src/rules/use-logical-properties-and-values/index.test.js
@@ -256,3 +256,31 @@ testRule({
     },
   ],
 });
+
+/* eslint-disable-next-line no-undef  */
+testRule({
+  ruleName,
+  config: [true, { 'overflow-y': false }],
+  plugins: ['./index.js'],
+  accept: [
+    {
+      code: `div {
+  overflow-y: auto;
+};`,
+      description: 'Allow overflow-y when the option is disabled with false.',
+    },
+  ],
+});
+
+/* eslint-disable-next-line no-undef  */
+testRule({
+  ruleName,
+  config: [true, { top: 'off' }],
+  plugins: ['./index.js'],
+  accept: [
+    {
+      code: 'div { top: 1rem; };',
+      description: 'Allow top when the option is disabled off.',
+    },
+  ],
+});


### PR DESCRIPTION
## 📒 Description

Adds support for passing in a physical property as an option to disable linting that specific property.

## 🚀 Changes

- Adds options check for rules
- Adds tests to support options
- Updates rule reporting to underline for property name

## 🔐 Closes

N/A

## ⛳️ Testing

Ran `npm run test` to ensure everything passes
