### PR TITLE
Support Physical Unit Options

### DIFF
--- a/src/rules/use-logical-units/index.js
+++ b/src/rules/use-logical-units/index.js
@@ -20,6 +20,14 @@ const ruleFunction = (_, options, context) => {
       if (!unitIsPhysical) return;
 
       const physicalUnit = getValueUnit(decl.value);
+
+      if (
+        options?.[physicalUnit] === false ||
+        options?.[physicalUnit] === 'off'
+      ) {
+        return;
+      }
+
       const message = ruleMessages.unexpectedUnit(
         physicalUnit,
         physicalUnitsMap[physicalUnit],

--- a/src/rules/use-logical-units/index.test.js
+++ b/src/rules/use-logical-units/index.test.js
@@ -29,3 +29,23 @@ testRule({
     })),
   ],
 });
+
+/* eslint-disable-next-line no-undef  */
+testRule({
+  ruleName,
+  config: [true, { dvh: false }],
+  plugins: ['./index.js'],
+  accept: [
+    {
+      code: 'div { top: 1dvh; };',
+      description: 'Allow dvh unit when the option is disabled.',
+    },
+  ],
+  reject: [
+    {
+      code: 'div { top: 1dvw; };',
+      description: 'Using a physical unit that is not disabled in the options.',
+      message: messages.unexpectedUnit('dvw', 'dvi'),
+    },
+  ],
+});


### PR DESCRIPTION
## 📒 Description

Supports passing options to bypass linting specific physical units.

## 🚀 Changes

- adds a check if the options include a unit to skip linting
- adds tests for accept and reject cases

## 🔐 Closes

NM/A

## ⛳️ Testing

> List of tests completed to verify the change

- ran `npm run test` to ensure all tests pass.
