### PR TITLE
Enable Linting Transition Properties

### DIFF
--- a/src/rules/use-logical-properties-and-values/base.js
+++ b/src/rules/use-logical-properties-and-values/base.js
@@ -11,6 +11,9 @@ const ruleMessages = stylelint.utils.ruleMessages(ruleName, {
   unexpectedValue(property, physicalValue, logicalValue) {
     return `Unexpected "${physicalValue}" value in "${property}" property. Use "${logicalValue}".`;
   },
+  unexpectedTransitionValue(physicalValue, logicalValue) {
+    return `Unexpected "${physicalValue}" value in "transition" property. Use "${logicalValue}".`;
+  },
 });
 
 const ruleMeta = {

--- a/src/rules/use-logical-properties-and-values/index.js
+++ b/src/rules/use-logical-properties-and-values/index.js
@@ -31,24 +31,46 @@ const ruleFunction = (_, options, context) => {
         (prefix) => (rootProp = rootProp.replace(prefix, '')),
       );
 
-      const isValidProp = Object.values(physicalProperties).includes(rootProp);
+      const isValidProp = [
+        ...Object.values(physicalProperties),
+        'transition',
+      ].includes(rootProp);
       if (!isValidProp) return;
 
+      const isTransitionProperty = rootProp === 'transition';
+      const physicalTransitionValue =
+        isTransitionProperty &&
+        Object.values(physicalProperties).find((property) =>
+          decl.value.includes(property) ? property : null,
+        );
       const propIsPhysical = isPhysicalProperty(decl.prop);
       const valueIsPhysical = isPhysicalValue(decl.value);
 
-      if (!propIsPhysical && !valueIsPhysical) return;
+      if (!propIsPhysical && !valueIsPhysical && !physicalTransitionValue)
+        return;
 
-      const message = propIsPhysical
-        ? ruleMessages.unexpectedProp(
-            decl.prop,
-            physicalPropertiesMap[rootProp],
-          )
-        : ruleMessages.unexpectedValue(
-            decl.prop,
-            decl.value,
-            physicalValuesMap[rootProp][decl.value],
-          );
+      let message;
+
+      if (propIsPhysical) {
+        message = ruleMessages.unexpectedProp(
+          decl.prop,
+          physicalPropertiesMap[rootProp],
+        );
+      }
+      if (valueIsPhysical) {
+        message = ruleMessages.unexpectedValue(
+          decl.prop,
+          decl.value,
+          physicalValuesMap[rootProp][decl.value],
+        );
+      }
+
+      if (physicalTransitionValue) {
+        message = ruleMessages.unexpectedTransitionValue(
+          physicalTransitionValue,
+          physicalPropertiesMap[physicalTransitionValue],
+        );
+      }
 
       if (context.fix && !options?.['disable-auto-fix']) {
         if (propIsPhysical) {
@@ -57,6 +79,13 @@ const ruleFunction = (_, options, context) => {
 
         if (valueIsPhysical) {
           decl.value = physicalValuesMap[rootProp][decl.value];
+        }
+
+        if (physicalTransitionValue) {
+          decl.value = decl.value.replace(
+            physicalTransitionValue,
+            physicalPropertiesMap[physicalTransitionValue],
+          );
         }
 
         return;

--- a/src/rules/use-logical-properties-and-values/index.test.js
+++ b/src/rules/use-logical-properties-and-values/index.test.js
@@ -28,6 +28,10 @@ testRule({
       code: 'div { box-orient: block-axis; };',
       description: 'Testing to -webkit-box-orient property',
     },
+    {
+      code: 'div { transition: inline-size 1s ease; };',
+      description: 'Testing a transition property with logical property value.',
+    },
 
     // PROPERTIES TO SKIP
     {
@@ -135,6 +139,12 @@ testRule({
     })),
 
     // VALUES
+    {
+      code: 'div { transition: width 1s ease; };',
+      description: 'Using a transition property with physical property value.',
+      message: messages.unexpectedTransitionValue('width', 'inline-size'),
+      fixed: 'div { transition: inline-size 1s ease; };',
+    },
     {
       code: 'p { -webkit-box-orient: vertical; };',
       description: 'Using a physical -webkit-box-orient value',


### PR DESCRIPTION
## 📒 Description

- enables linting for physical properties inside of transition styles

## 🚀 Changes

- adds lint check for transition styles
- adds tests for transition styles
- adds auto fixing of transition styles

## 🔐 Closes

N/A

## ⛳️ Testing

- ran `npm run test` to ensure all tests pass
