### PR TITLE
Support Container Query Unit Linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ body {
 
 | Physical Unit |  Logical Unit |
 | ------------- | ------------- |
+| cqh           | cqb           |
+| cqw           | cqi           |
 | dvh           | dvb           |
 | dvw           | dvi           |
 | lvh           | lvb           |

--- a/src/utils/isPhysicalUnit.js
+++ b/src/utils/isPhysicalUnit.js
@@ -1,6 +1,6 @@
 const { physicalUnits } = require('./physical');
 
-const expression = /(\d+\s?)(dvh|dvw|lvh|lvw|svh|svw|vh|vw|)(\s+|$)/;
+const expression = /(\d+\s?)(cqh|cqw|dvh|dvw|lvh|lvw|svh|svw|vh|vw|)(\s+|$)/;
 
 function getValueUnit(value) {
   const match = value.match(expression);

--- a/src/utils/logical.js
+++ b/src/utils/logical.js
@@ -86,6 +86,8 @@ const logicalProperties = Object.freeze({
 });
 
 const logicalUnits = Object.freeze({
+  cqb: 'cqb',
+  cqi: 'cqi',
   dvb: 'dvb',
   dvi: 'dvi',
   lvb: 'lvb',

--- a/src/utils/physical.js
+++ b/src/utils/physical.js
@@ -67,6 +67,8 @@ const physicalProperties = Object.freeze({
 });
 
 const physicalUnits = Object.freeze({
+  cqh: 'cqh',
+  cqw: 'cqw',
   dvh: 'dvh',
   dvw: 'dvw',
   lvh: 'lvh',

--- a/src/utils/physicalUnitsMap.js
+++ b/src/utils/physicalUnitsMap.js
@@ -2,6 +2,8 @@ const { logicalUnits } = require('./logical');
 const { physicalUnits } = require('./physical');
 
 const physicalUnitsMap = Object.freeze({
+  [physicalUnits.cqh]: logicalUnits.cqb,
+  [physicalUnits.cqw]: logicalUnits.cqi,
   [physicalUnits.dvh]: logicalUnits.dvb,
   [physicalUnits.dvw]: logicalUnits.dvi,
   [physicalUnits.lvh]: logicalUnits.lvb,


### PR DESCRIPTION
## 📒 Description

- adds `cqh` and `cqw` container query linting

## 🚀 Changes

- adds linting for container query units `cqh`, `cqw` => `cqb`, `cqi`

## 🔐 Closes

N/A

## ⛳️ Testing

- ran `npm run test` to make sure all tests pass
