### PR TITLE
Remove Own `disable-auto-fix` Option for Stylelint `disableFix` Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,9 @@ physical property or value is found, it will be flagged.
 
 #### Options
 
-| Option           | Description                                                              |
-| ---------------- | ------------------------------------------------------------------------ |
-| disable-auto-fix | Use this option to prevent auto-fixing warnings and errors while saving. |
-| ignore           | Pass an array of physical properties to ignore while linting.            |
+| Option | Description                                                   |
+| ------ | ------------------------------------------------------------- |
+| ignore | Pass an array of physical properties to ignore while linting. |
 
 ```json
 {
@@ -77,7 +76,6 @@ physical property or value is found, it will be flagged.
       true,
       {
         "severity": "warning",
-        "disable-auto-fix": true,
         "ignore": ["overflow-y", "overflow-x"]
       }
     ]
@@ -240,10 +238,9 @@ directions. Instead, this rule will enforce the logical equivalents, `vi` and
 
 #### Options
 
-| Option           | Description                                                              |
-| ---------------- | ------------------------------------------------------------------------ |
-| disable-auto-fix | Use this option to prevent auto-fixing warnings and errors while saving. |
-| ignore           | Pass an array of physical units to ignore while linting.                 |
+| Option | Description                                              |
+| ------ | -------------------------------------------------------- |
+| ignore | Pass an array of physical units to ignore while linting. |
 
 ```json
 {
@@ -252,7 +249,6 @@ directions. Instead, this rule will enforce the logical equivalents, `vi` and
       true,
       {
         "severity": "warning",
-        "disable-auto-fix": true,
         "ignore": ["dvh", "dvw"]
       }
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "stylelint-plugin-logical-css",
-  "version": "0.0.5",
+  "version": "0.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "stylelint-plugin-logical-css",
-      "version": "0.0.5",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^17.4.4",

--- a/src/rules/use-logical-properties-and-values/index.js
+++ b/src/rules/use-logical-properties-and-values/index.js
@@ -81,7 +81,7 @@ const ruleFunction = (_, options, context) => {
         );
       }
 
-      if (context.fix && !options?.['disable-auto-fix']) {
+      if (context.fix) {
         if (propIsPhysical) {
           decl.prop = physicalPropertiesMap[rootProp];
         }

--- a/src/rules/use-logical-properties-and-values/index.test.js
+++ b/src/rules/use-logical-properties-and-values/index.test.js
@@ -307,9 +307,7 @@ testRule({
   plugins: ['./index.js'],
   accept: [
     {
-      code: `div {
-  overflow-y: auto;
-};`,
+      code: `div { overflow-y: auto; };`,
       description: 'Allow overflow-y when the option is disabled with false.',
     },
   ],

--- a/src/rules/use-logical-units/index.js
+++ b/src/rules/use-logical-units/index.js
@@ -7,6 +7,7 @@ const { getValueUnit, isPhysicalUnit } = require('../../utils/isPhysicalUnit');
 const { physicalUnitsMap } = require('../../utils/physicalUnitsMap');
 
 const ruleFunction = (_, options, context) => {
+  console.log({ options, context });
   return (root, result) => {
     const validOptions = stylelint.utils.validateOptions(result, ruleName);
 
@@ -33,7 +34,7 @@ const ruleFunction = (_, options, context) => {
         physicalUnitsMap[physicalUnit],
       );
 
-      if (context.fix && !options?.['disable-auto-fix']) {
+      if (context.fix) {
         decl.value = decl.value.replace(
           physicalUnit,
           physicalUnitsMap[physicalUnit],


### PR DESCRIPTION
## 📒 Description

- removes the plugin's `disable-auto-fix` option
- checks against the default Stylelint `fix` option to determine whether or not to fix found issues

## 🚀 Changes

- removes the plugin's `disable-auto-fix` option

## 🔐 Closes

#18 

## ⛳️ Testing

- all tests pass
