### PR TITLE
fix: remove console.log

### DIFF
--- a/src/rules/use-logical-units/index.js
+++ b/src/rules/use-logical-units/index.js
@@ -7,7 +7,6 @@ const { getValueUnit, isPhysicalUnit } = require('../../utils/isPhysicalUnit');
 const { physicalUnitsMap } = require('../../utils/physicalUnitsMap');
 
 const ruleFunction = (_, options, context) => {
-  console.log({ options, context });
   return (root, result) => {
     const validOptions = stylelint.utils.validateOptions(result, ruleName);
 


### PR DESCRIPTION
## 📒 Description

Plugin shows unnecessary information in the console.

## 🚀 Changes

Remove `console.log`.

## 🔐 Closes

N/A

## ⛳️ Testing

N/A