### PR TITLE
fix: fix using float values with units

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "stylelint-plugin-logical-css",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
+      "name": "stylelint-plugin-logical-css",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^18.4.3",

--- a/src/rules/use-logical-units/index.test.js
+++ b/src/rules/use-logical-units/index.test.js
@@ -53,6 +53,12 @@ testRule({
       ),
       fixed: `div { inline-size: clamp(80vb, 50%, 90vi); };`,
     },
+    {
+      code: 'div { inline-size: 50.5vw; };',
+      description: 'Testing float physical unit',
+      message: messages.unexpectedUnit('vw', physicalUnitsMap.vw),
+      fixed: `div { inline-size: 50.5vi; };`,
+    },
   ],
 });
 

--- a/src/utils/isPhysicalUnit.js
+++ b/src/utils/isPhysicalUnit.js
@@ -10,7 +10,7 @@ export function getValueUnit(value) {
   const matches = Array.isArray(match) ? match : [match];
 
   const matchedUnit = matches.map(
-    (match) => physicalUnits[match.replace(/[0-9]/g, '')],
+    (match) => physicalUnits[match.replace(/[0-9](\.[0-9])?/g, '')],
   );
 
   return matchedUnit;


### PR DESCRIPTION
## 📒 Description

Currently, we cannot use units with float values.

```
TypeError: Cannot read properties of undefined (reading 'includes')
```

## 🚀 Changes

Fixes the regular expression and allows float numbers to be used.

## 🔐 Closes

N/A.

## ⛳️ Testing

Added test.
