### PR TITLE
Fix False Positives for Caption Side Block Axis Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ physical property or value is found, it will be flagged.
   max-width: 90ch; /* Will flag the use of "width" */
   text-align: left; /* Will flag the use of "left" */
   opacity: 1;
-  transition: opacity 1s ease, max-width 1s ease; /* Will flag the use of 'max-width' */
+  transition:
+    opacity 1s ease,
+    max-width 1s ease; /* Will flag the use of 'max-width' */
 }
 ```
 
@@ -196,8 +198,6 @@ physical property or value is found, it will be flagged.
 | ---------------------------------------------- | ----------------------------------- |
 | `(-webkit-)box-orient: vertical`               | `(-webkit-)box-orient: block-axis`  |
 | `(-webkit-)box-orient: horizontal`             | `(-webkit-)box-orient: inline-axis` |
-| `caption-side: top`                            | `caption-side: block-start`         |
-| `caption-side: bottom`                         | `caption-side: block-end`           |
 | `caption-side: right`                          | `caption-side: inline-end`          |
 | `caption-side: left`                           | `caption-side: inline-start`        |
 | `overflow-y`                                   | `overflow-block`                    |
@@ -272,7 +272,11 @@ body {
 }
 
 .container {
-  inline-size: clamp(10vw, 100%, 50vw); /* Will flag the physical use of viewport "width" */
+  inline-size: clamp(
+    10vw,
+    100%,
+    50vw
+  ); /* Will flag the physical use of viewport "width" */
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-logical-css",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Stylelint plugin to enforce the use of logical CSS properties, values and units.",
   "main": "src/index.js",
   "type": "module",

--- a/src/rules/use-logical-properties-and-values/index.js
+++ b/src/rules/use-logical-properties-and-values/index.js
@@ -35,6 +35,10 @@ const ruleFunction = (_, options, context) => {
       ].includes(rootProp);
       if (!isValidProp) return;
 
+      const isCaptionSideProperty = rootProp === 'caption-side';
+      const isBlockAxisCaptionSideValue =
+        isCaptionSideProperty && ['top', 'bottom'].includes(decl.value);
+
       const isTransitionProperty = rootProp === 'transition';
       const physicalTransitionProperties =
         isTransitionProperty &&
@@ -49,9 +53,10 @@ const ruleFunction = (_, options, context) => {
       const valueIsPhysical = isPhysicalValue(decl.value);
 
       if (
-        !propIsPhysical &&
-        !valueIsPhysical &&
-        !physicalTransitionProperties.length
+        (!propIsPhysical &&
+          !valueIsPhysical &&
+          !physicalTransitionProperties.length) ||
+        isBlockAxisCaptionSideValue
       ) {
         return;
       }
@@ -64,6 +69,7 @@ const ruleFunction = (_, options, context) => {
           physicalPropertiesMap[rootProp],
         );
       }
+
       if (valueIsPhysical) {
         message = ruleMessages.unexpectedValue(
           decl.prop,
@@ -71,6 +77,7 @@ const ruleFunction = (_, options, context) => {
           physicalValuesMap[rootProp][decl.value],
         );
       }
+
       if (physicalTransitionProperties.length) {
         const propertyToFlag = physicalTransitionProperties[0].trim();
         message = ruleMessages.unexpectedTransitionValue(

--- a/src/rules/use-logical-properties-and-values/index.test.js
+++ b/src/rules/use-logical-properties-and-values/index.test.js
@@ -82,12 +82,12 @@ testRule({
 
     // VALUES
     {
-      code: 'table { display: flex; caption-side: block-start; };',
-      description: 'Using a logical caption-side value',
+      code: 'table { caption-side: bottom; };',
+      description: 'Testing block-xx caption side property to skip',
     },
     {
-      code: 'table { caption-side: block-end; };',
-      description: 'Using a logical caption-side value',
+      code: 'table { caption-side: top; };',
+      description: 'Testing block-xx caption side property to skip',
     },
     {
       code: 'table { caption-side: inline-start; };',
@@ -222,12 +222,6 @@ testRule({
       fixed: 'p { box-orient: inline-axis; };',
     },
     {
-      code: 'table { caption-side: bottom; };',
-      description: 'Using a physical caption-side value',
-      message: messages.unexpectedValue('caption-side', 'bottom', 'block-end'),
-      fixed: 'table { caption-side: block-end; };',
-    },
-    {
       code: 'table { caption-side: left; };',
       description: 'Using a physical caption-side value',
       message: messages.unexpectedValue('caption-side', 'left', 'inline-start'),
@@ -238,12 +232,6 @@ testRule({
       description: 'Using a physical caption-side value',
       message: messages.unexpectedValue('caption-side', 'right', 'inline-end'),
       fixed: 'table { caption-side: inline-end; };',
-    },
-    {
-      code: 'table { caption-side: top; };',
-      description: 'Using a physical caption-side value',
-      message: messages.unexpectedValue('caption-side', 'top', 'block-start'),
-      fixed: 'table { caption-side: block-start; };',
     },
     {
       code: 'div { clear: left; };',

--- a/src/utils/physicalValuesMap.js
+++ b/src/utils/physicalValuesMap.js
@@ -11,10 +11,8 @@ export const physicalValuesMap = Object.freeze({
     [physicalAxis.vertical]: `${logicalAxis.block}-axis`,
   },
   [physicalProperties.captionSide]: {
-    [physicalValues.bottom]: logicalValues.blockEnd,
     [physicalValues.left]: logicalValues.inlineStart,
     [physicalValues.right]: logicalValues.inlineEnd,
-    [physicalValues.top]: logicalValues.blockStart,
   },
   [physicalProperties.clear]: {
     [physicalValues.left]: logicalValues.inlineStart,


### PR DESCRIPTION
## 📒 Description

- removes checks for `caption-side` `top` and `bottom`

## 🚀 Changes

- remove checks for block-axis caption-side values
- updates tests to support check
- increments package version
- updates docs

## 🔐 Closes

- #30 

## ⛳️ Testing

- run `npm run test` to verify all tests pass