### PR TITLE
chore: inset is not a logical property

### DIFF
--- a/src/utils/logical.js
+++ b/src/utils/logical.js
@@ -44,7 +44,6 @@ export const logicalProperties = Object.freeze({
   containIntrinsicBlockSize: 'contain-intrinsic-block-size',
   containIntrinsicInlineSize: 'contain-intrinsic-inline-size',
   inlineSize: 'inline-size',
-  inset: 'inset',
   insetBlock: 'inset-block',
   insetBlockEnd: 'inset-block-end',
   insetBlockStart: 'inset-block-start',


### PR DESCRIPTION
## 📒 Description

Remove `inset` from `logicalProperties`, because `inset` is not a logical property.

> While part of the [CSS logical properties and values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values) module, it does not define logical offsets. It defines physical offsets, regardless of the element's writing mode, directionality, and text orientation.

— https://developer.mozilla.org/en-US/docs/Web/CSS/inset

## 🚀 Changes

- Remove `inset` from `logicalProperties`.

## 🔐 Closes

N/A

## ⛳️ Testing

N/A
