### PR TITLE
fix: ignore physical properties within transition when configured

### DIFF
--- a/src/rules/use-logical-properties-and-values/index.js
+++ b/src/rules/use-logical-properties-and-values/index.js
@@ -43,6 +43,7 @@ const ruleFunction = (_, options, context) => {
       const physicalTransitionProperties =
         isTransitionProperty &&
         Object.values(physicalProperties)
+          .filter((property) => !(options?.ignore || []).includes(property))
           .flatMap((property) => {
             const exp = new RegExp(`(^|[^\\w-])${property}([^\\w-]|$)`);
             return decl.value.match(exp);

--- a/src/rules/use-logical-properties-and-values/index.test.js
+++ b/src/rules/use-logical-properties-and-values/index.test.js
@@ -288,12 +288,24 @@ testRule({
 /* eslint-disable-next-line no-undef  */
 testRule({
   ruleName,
-  config: [true, { ignore: ['overflow-y'] }],
+  config: [true, { ignore: ['height', 'overflow-y'] }],
   plugins: ['./index.js'],
   accept: [
     {
       code: `div { overflow-y: auto; };`,
       description: 'Allow overflow-y when the option is disabled with false.',
+    },
+    {
+      code: `div { transition: height 1s ease-in-out; };`,
+      description: 'Allow height within transition when the property is ignored',
+    }
+  ],
+  reject: [
+    {
+      code: `div { transition: width 1s ease-in-out; };`,
+      description: 'Using a physical property within transition that is not ignored',
+      message: messages.unexpectedTransitionValue("width", "inline-size"),
+      fixed: `div { transition: inline-size 1s ease-in-out; };`,
     },
   ],
 });


### PR DESCRIPTION
## 📒 Description

Currently the `use-logical-properties-and-values` rule does not ignore the configured `ignore` physical properties within `transition`.

Steps to reproduce the behavior:
1. Configure the rule with some ignored properties
```js
"plugin/use-logical-properties-and-values": [
  true,
  {
    severity: "error",
    ignore: ["height"],
  },
]
```
2. Create a stylesheet with a transition property that uses the ignored rule `height`
```css
.my-class {
  transition: height 1s ease-in-out
}
```
3. See error

## 🚀 Changes

Adds ignore functionality to `transition` which I think would be the intended behavior, but let me know if that's not the case.

## 🔐 Closes

N/A. Small enough issue where I hope this PR is sufficient for any discussion.

## ⛳️ Testing

Added test